### PR TITLE
text.select(): t undefined in scope

### DIFF
--- a/R/updatePackages.R
+++ b/R/updatePackages.R
@@ -91,34 +91,33 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
 ) {
   
   assert_that(is_path(path))
-  
-  do_one <- function(t) {
-    
-    text.select <- function(old) {
-      update <- NULL
-      for (k in seq_len(nrow(old))) {
-        cat(old[k, "Package"], ":\n",
+
+  text.select <- function(old) {
+    update <- NULL
+    for (k in seq_len(nrow(old))) {
+      cat(old[k, "Package"], ":\n",
           "Local Version", old[k, "LocalVer"], "\n",
           "Repos Version", old[k, "ReposVer"],
           "available at", simplifyRepos(old[k, "Repository"], t))
-        cat("\n")
-        answer <- substr(readline("Update (y/N/c)?  "), 1L, 1L)
-        if (answer == "c" | answer == "C") {
-          cat("cancelled by user\n")
-          return(invisible())
-        }
-        if (answer == "y" | answer == "Y") update <- rbind(update, old[k, ])
+      cat("\n")
+      answer <- substr(readline("Update (y/N/c)?  "), 1L, 1L)
+      if (answer == "c" | answer == "C") {
+        cat("cancelled by user\n")
+        return(invisible())
       }
-      update
+      if (answer == "y" | answer == "Y") update <- rbind(update, old[k, ])
     }
-    
-    simplifyRepos <- function(repos, t) {
-      tail <- substring(contribUrl("---", type = t, Rversion = Rversion), 4)
-      ind <- regexpr(tail, repos, fixed = TRUE)
-      ind <- ifelse(ind > 0, ind - 1, nchar(repos, type = "c"))
-      substr(repos, 1, ind)
-    }
-    
+    update
+  }
+  
+  simplifyRepos <- function(repos, t) {
+    tail <- substring(contribUrl("---", type = t, Rversion = Rversion), 4)
+    ind <- regexpr(tail, repos, fixed = TRUE)
+    ind <- ifelse(ind > 0, ind - 1, nchar(repos, type = "c"))
+    substr(repos, 1, ind)
+  }
+  
+  do_one <- function(t) {
     force(ask)
     if (!is.matrix(oldPkgs) && is.character(oldPkgs)) {
       subset <- oldPkgs
@@ -128,7 +127,7 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
     }
     if (is.null(oldPkgs)) {
       oldPkgs <- oldPackages(path = path, repos = repos, method = method,
-        availPkgs = availPkgs, type = t, Rversion = Rversion)
+                             availPkgs = availPkgs, type = t, Rversion = Rversion)
       if (is.null(oldPkgs)) {
         message("All packages are up to date from repos: ", names(repos))
         return(invisible())
@@ -144,7 +143,7 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
       if (.Platform$OS.type == " windows" || .Platform$GUI == "AQUA" ||
           (capabilities("tcltk") && capabilities("X11"))) {
         k <- select.list(oldPkgs[, 1L], oldPkgs[, 1L], multiple = TRUE,
-          title = "Packages to be updated", graphics = TRUE)
+                         title = "Packages to be updated", graphics = TRUE)
         oldPkgs[match(k, oldPkgs[, 1L]), , drop = FALSE]
       } else {
         text.select(oldPkgs)
@@ -156,7 +155,7 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
     }
     if (length(update[, "Package"])) {
       addPackage(update[, "Package"], path = path, repos = repos, type = t,
-        quiet = quiet, deps = FALSE, Rversion = Rversion)
+                 quiet = quiet, deps = FALSE, Rversion = Rversion)
     }
   }
 

--- a/R/updatePackages.R
+++ b/R/updatePackages.R
@@ -91,33 +91,34 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
 ) {
   
   assert_that(is_path(path))
-
-  text.select <- function(old) {
-    update <- NULL
-    for (k in seq_len(nrow(old))) {
-      cat(old[k, "Package"], ":\n",
+  
+  do_one <- function(t) {
+    
+    text.select <- function(old) {
+      update <- NULL
+      for (k in seq_len(nrow(old))) {
+        cat(old[k, "Package"], ":\n",
           "Local Version", old[k, "LocalVer"], "\n",
           "Repos Version", old[k, "ReposVer"],
           "available at", simplifyRepos(old[k, "Repository"], t))
-      cat("\n")
-      answer <- substr(readline("Update (y/N/c)?  "), 1L, 1L)
-      if (answer == "c" | answer == "C") {
-        cat("cancelled by user\n")
-        return(invisible())
+        cat("\n")
+        answer <- substr(readline("Update (y/N/c)?  "), 1L, 1L)
+        if (answer == "c" | answer == "C") {
+          cat("cancelled by user\n")
+          return(invisible())
+        }
+        if (answer == "y" | answer == "Y") update <- rbind(update, old[k, ])
       }
-      if (answer == "y" | answer == "Y") update <- rbind(update, old[k, ])
+      update
     }
-    update
-  }
-  
-  simplifyRepos <- function(repos, t) {
-    tail <- substring(contribUrl("---", type = t, Rversion = Rversion), 4)
-    ind <- regexpr(tail, repos, fixed = TRUE)
-    ind <- ifelse(ind > 0, ind - 1, nchar(repos, type = "c"))
-    substr(repos, 1, ind)
-  }
-  
-  do_one <- function(t) {
+    
+    simplifyRepos <- function(repos, t) {
+      tail <- substring(contribUrl("---", type = t, Rversion = Rversion), 4)
+      ind <- regexpr(tail, repos, fixed = TRUE)
+      ind <- ifelse(ind > 0, ind - 1, nchar(repos, type = "c"))
+      substr(repos, 1, ind)
+    }
+    
     force(ask)
     if (!is.matrix(oldPkgs) && is.character(oldPkgs)) {
       subset <- oldPkgs
@@ -127,7 +128,7 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
     }
     if (is.null(oldPkgs)) {
       oldPkgs <- oldPackages(path = path, repos = repos, method = method,
-                             availPkgs = availPkgs, type = t, Rversion = Rversion)
+        availPkgs = availPkgs, type = t, Rversion = Rversion)
       if (is.null(oldPkgs)) {
         message("All packages are up to date from repos: ", names(repos))
         return(invisible())
@@ -143,7 +144,7 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
       if (.Platform$OS.type == " windows" || .Platform$GUI == "AQUA" ||
           (capabilities("tcltk") && capabilities("X11"))) {
         k <- select.list(oldPkgs[, 1L], oldPkgs[, 1L], multiple = TRUE,
-                         title = "Packages to be updated", graphics = TRUE)
+          title = "Packages to be updated", graphics = TRUE)
         oldPkgs[match(k, oldPkgs[, 1L]), , drop = FALSE]
       } else {
         text.select(oldPkgs)
@@ -155,7 +156,7 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
     }
     if (length(update[, "Package"])) {
       addPackage(update[, "Package"], path = path, repos = repos, type = t,
-                 quiet = quiet, deps = FALSE, Rversion = Rversion)
+        quiet = quiet, deps = FALSE, Rversion = Rversion)
     }
   }
 

--- a/R/updatePackages.R
+++ b/R/updatePackages.R
@@ -29,7 +29,7 @@
 #' @family update repo functions
 #'
 #' @example /inst/examples/example_updatePackages.R
-#'   
+#'
 oldPackages <- function(path = NULL, repos = getOption("repos"),
                         availPkgs = pkgAvail(repos = repos,
                                              type = type,
@@ -84,15 +84,15 @@ oldPackages <- function(path = NULL, repos = getOption("repos"),
 #' @return `updatePackages` returns `NULL` invisibly.
 #'
 #' @export
-#' 
+#'
 updatePackages <- function(path = NULL, repos = getOption("repos"), method = NULL, ask = TRUE,
                            availPkgs = pkgAvail(repos = repos, type = type, Rversion = Rversion),
                            oldPkgs = NULL, type = "source", Rversion = R.version, quiet = FALSE
 ) {
-  
+
   assert_that(is_path(path))
 
-  text.select <- function(old) {
+  text.select <- function(old, t) {
     update <- NULL
     for (k in seq_len(nrow(old))) {
       cat(old[k, "Package"], ":\n",
@@ -109,14 +109,14 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
     }
     update
   }
-  
+
   simplifyRepos <- function(repos, t) {
     tail <- substring(contribUrl("---", type = t, Rversion = Rversion), 4)
     ind <- regexpr(tail, repos, fixed = TRUE)
     ind <- ifelse(ind > 0, ind - 1, nchar(repos, type = "c"))
     substr(repos, 1, ind)
   }
-  
+
   do_one <- function(t) {
     force(ask)
     if (!is.matrix(oldPkgs) && is.character(oldPkgs)) {
@@ -146,10 +146,10 @@ updatePackages <- function(path = NULL, repos = getOption("repos"), method = NUL
                          title = "Packages to be updated", graphics = TRUE)
         oldPkgs[match(k, oldPkgs[, 1L]), , drop = FALSE]
       } else {
-        text.select(oldPkgs)
+        text.select(oldPkgs, t)
       }
     } else if (isTRUE(ask)) {
-      text.select(oldPkgs)
+      text.select(oldPkgs, t)
     } else {
       oldPkgs
     }


### PR DESCRIPTION
Both functions are in outside of the enviroment of do_one, which causes that t is the base matrix transpose function. Which causes an error: 

Error in type == "both" : 
  comparison (1) is possible only for atomic and list types

I don't know why it worked before, but this solved the issue for me.