### PR TITLE
Do not ignore writePACKAGES parameter

### DIFF
--- a/R/addPackages.R
+++ b/R/addPackages.R
@@ -355,7 +355,7 @@ addLocalPackage <- function(pkgs = NULL, pkgPath = NULL, path = NULL,
   sapply(type, do_one)
 
   # write package index for each folder:
-  index <- updateRepoIndex(path = path, type = type, Rversion = Rversion)
+  index <- if (writePACKAGES) updateRepoIndex(path = path, type = type, Rversion = Rversion)
 
   invisible(index)
 }


### PR DESCRIPTION
Just a small PR to make use of the forgotten argument `writePACKAGES` in `addLocalPackage()` and to make it consistent with the rest of the "addPackage" functions.