### PR TITLE
Make recursion optional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Version: 0.2.16.9000
 Authors@R: c(
     person("Andrie", "de Vries", role=c("aut", "cre", "cph"), email="apdevries@gmail.com"),
     person("Alex", "Chubaty", role="ctb", email="alex.chubaty@gmail.com"),
+    person("Alexandre", "Courtiol", role="ctb", email="alexandre.courtiol@gmail.com"),
     person("Microsoft Corporation", role="cph")
     )
 License: GPL-2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
 LazyData: true
 LazyLoad: true
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 Language: en-US

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+miniCRAN v0.2.17
+================
+
+* `makeDepGraph()` and `pkgDep()` gain an argument `recursive` to control whether dependencies of dependencies are retrieved or not (default = TRUE for default behaviour identical to previous versions) (#149)
+
+
 miniCRAN v0.2.16
 ================
 
@@ -44,7 +50,7 @@ Minor changes:
 miniCRAN v0.2.12 (Release date: 2019-07-06)
 ================
 
-New features: 
+New features:
 * None
 
 Bug fixes:
@@ -65,7 +71,7 @@ Internal changes
 miniCRAN v0.2.11 (Release date: 2018-01-15)
 ================
 
-New features: 
+New features:
 * None
 
 Bug fixes:

--- a/R/makeDepGraph.R
+++ b/R/makeDepGraph.R
@@ -42,7 +42,8 @@ addDepType <- function(p, type = c("Imports", "Depends", "LinkingTo", "Suggests"
 makeDepGraph <- function(
   pkg, availPkgs, repos = getOption("repos"), type = "source",
   suggests = TRUE, enhances = FALSE,
-  includeBasePkgs = FALSE, ...)
+  includeBasePkgs = FALSE,
+  recursive = TRUE, ...)
 {
 
   if (missing(availPkgs)) {
@@ -87,7 +88,7 @@ makeDepGraph <- function(
   p_dep <- unique(unlist(
                   tools::package_dependencies(
                     pkg, db = availPkgs,
-                    which = c("Imports", "Depends", "LinkingTo"), recursive = TRUE)
+                    which = c("Imports", "Depends", "LinkingTo"), recursive = recursive)
   ))
   pkg <- unique(c(p_dep, pkg))
 
@@ -102,6 +103,9 @@ makeDepGraph <- function(
   nedges <- nrow(edges)
   if (nedges && !includeBasePkgs)
     edges <- edges[!(edges[["dep"]] %in% basePkgs()), ]
+
+  if (nedges && !recursive)
+    edges <- edges[(edges[["dep"]] %in% p_dep), ]
 
   vert <- unique(c(pkg_orig, edges[["dep"]], edges[["package"]]))
   ret <- igraph::graph.data.frame(d = edges, directed = TRUE, vertices = vert)

--- a/R/makeDepGraph.R
+++ b/R/makeDepGraph.R
@@ -46,6 +46,9 @@ makeDepGraph <- function(
   recursive = TRUE, ...)
 {
 
+  if (is.character(recursive))
+    stop("The argument recursive must be a logicial (TRUE or FALSE).")
+
   if (missing(availPkgs)) {
     availPkgs <- pkgAvail(repos = repos, type = type)
   }
@@ -85,9 +88,14 @@ makeDepGraph <- function(
     ))
     pkg <- unique(c(p_enh, pkg))
   }
+
+  pkg2 <- pkg
+  if(!recursive)
+    pkg2 <- pkg_orig
+
   p_dep <- unique(unlist(
                   tools::package_dependencies(
-                    pkg, db = availPkgs,
+                    pkg2, db = availPkgs,
                     which = c("Imports", "Depends", "LinkingTo"), recursive = recursive)
   ))
   pkg <- unique(c(p_dep, pkg))
@@ -105,7 +113,7 @@ makeDepGraph <- function(
     edges <- edges[!(edges[["dep"]] %in% basePkgs()), ]
 
   if (nedges && !recursive)
-    edges <- edges[(edges[["dep"]] %in% p_dep), ]
+    edges <- edges[(edges[["dep"]] %in% pkg), ]
 
   vert <- unique(c(pkg_orig, edges[["dep"]], edges[["package"]]))
   ret <- igraph::graph.data.frame(d = edges, directed = TRUE, vertices = vert)

--- a/R/pkgDep.R
+++ b/R/pkgDep.R
@@ -14,7 +14,7 @@ basePkgs <- function()names(which(installed.packages()[, "Priority"] == "base"))
 
 #' Retrieves package dependencies.
 #'
-#' Performs recursive retrieve for `Depends`, `Imports` and `LinkLibrary`.
+#' Performs recursive or non-recursive retrieve for `Depends`, `Imports` and `LinkLibrary`.
 #' Performs non-recursive retrieve for `Suggests`.
 #'
 #'
@@ -42,7 +42,7 @@ basePkgs <- function()names(which(installed.packages()[, "Priority"] == "base"))
 #'
 #' @param includeBasePkgs If TRUE, include base R packages in results
 #'
-#' @param recursive If TRUE, (reverse) dependencies of (reverse) dependencies (and so on) should be included. Input can also be a character vector indicating the type of (reverse) dependencies to be added recursively
+#' @param recursive If TRUE, (reverse) dependencies of (reverse) dependencies (and so on) should be included
 #'
 #' @template Rversion
 #'
@@ -62,11 +62,13 @@ pkgDep <- function(pkg, availPkgs, repos = getOption("repos"), type = "source",
 {
   assert_that(is_package(pkg))
 
+  if (is.character(recursive))
+    stop("The argument recursive must be a logicial (TRUE or FALSE).")
+
   if (!depends & !suggests & !enhances) {
     warning("Returning nothing, since depends, suggests and enhances are all FALSE")
     return(character(0))
   }
-
 
   if (missing(availPkgs)) {
     if (!is.null(names(repos)) & repos["CRAN"] == "@CRAN@") {
@@ -110,7 +112,11 @@ pkgDep <- function(pkg, availPkgs, repos = getOption("repos"), type = "source",
   }
 
   # Depends, Imports and LinkingTo
-  p_dep <- tools::package_dependencies(n_req_all, availPkgs,
+  pkg2 <- n_req_all
+  if (!recursive)
+    pkg2 <- n_req
+
+  p_dep <- tools::package_dependencies(pkg2, availPkgs,
                                        which = c("Depends", "Imports", "LinkingTo"),
                                        recursive = recursive)
   n_dep <- unique(unname(unlist(p_dep)))

--- a/inst/examples/example_makeDepGraph.R
+++ b/inst/examples/example_makeDepGraph.R
@@ -1,32 +1,56 @@
 
 if (interactive()) {
   availPkgs <- cranJuly2014
-  
+
   availPkgs <- pkgAvail(
     repos = c(CRAN = "https://cloud.r-project.org"),
     type = "source"
   )
-  
-  
+
+
   # Create dependency graph using stored database of available packages
   p <- makeDepGraph(
     c("ggplot2", "forecast"),
     availPkgs = availPkgs
   )
-  
+
   if(require(igraph)) plot(p)
 
   # Create dependency graph using newly retrieved database from CRAN
-  
+
   p <- makeDepGraph(
     c("ggplot2", "forecast"),
     repos = c(CRAN = getOption("minicran.mran")),
     type = "source"
   )
+
+  if(require(igraph)) plot(p)
+
+  # Same thing without suggests
+
+  p <- makeDepGraph(
+    c("ggplot2", "forecast"),
+    repos = c(CRAN = getOption("minicran.mran")),
+    type = "source",
+    suggests = FALSE
+  )
+
+  if(require(igraph)) plot(p)
+
+
+  # Same thing without suggests and recursive dependencies
+
+  p <- makeDepGraph(
+    c("ggplot2", "forecast"),
+    repos = c(CRAN = getOption("minicran.mran")),
+    type = "source",
+    suggests = FALSE,
+    recursive = FALSE
+  )
+
   if(requireNamespace("igraph", quietly = TRUE)) {
     plot(p)
   } else {
     message("install package `igraph` to view dependency graph")
   }
-  
 }

--- a/man/makeDepGraph.Rd
+++ b/man/makeDepGraph.Rd
@@ -36,7 +36,7 @@ installed on other platforms.  Passed to \code{\link[=download.packages]{downloa
 
 \item{includeBasePkgs}{If TRUE, include base R packages in results}
 
-\item{recursive}{If TRUE, (reverse) dependencies of (reverse) dependencies (and so on) should be included. Input can also be a character vector indicating the type of (reverse) dependencies to be added recursively}
+\item{recursive}{If TRUE, (reverse) dependencies of (reverse) dependencies (and so on) should be included}
 
 \item{...}{Other arguments passed to \code{\link[=available.packages]{available.packages()}}}
 }

--- a/man/makeDepGraph.Rd
+++ b/man/makeDepGraph.Rd
@@ -12,6 +12,7 @@ makeDepGraph(
   suggests = TRUE,
   enhances = FALSE,
   includeBasePkgs = FALSE,
+  recursive = TRUE,
   ...
 )
 }
@@ -35,6 +36,8 @@ installed on other platforms.  Passed to \code{\link[=download.packages]{downloa
 
 \item{includeBasePkgs}{If TRUE, include base R packages in results}
 
+\item{recursive}{If TRUE, (reverse) dependencies of (reverse) dependencies (and so on) should be included. Input can also be a character vector indicating the type of (reverse) dependencies to be added recursively}
+
 \item{...}{Other arguments passed to \code{\link[=available.packages]{available.packages()}}}
 }
 \description{
@@ -44,34 +47,58 @@ Each package is a node, and a dependency is an edge
 
 if (interactive()) {
   availPkgs <- cranJuly2014
-  
+
   availPkgs <- pkgAvail(
     repos = c(CRAN = "https://cloud.r-project.org"),
     type = "source"
   )
-  
-  
+
+
   # Create dependency graph using stored database of available packages
   p <- makeDepGraph(
     c("ggplot2", "forecast"),
     availPkgs = availPkgs
   )
-  
+
   if(require(igraph)) plot(p)
 
   # Create dependency graph using newly retrieved database from CRAN
-  
+
   p <- makeDepGraph(
     c("ggplot2", "forecast"),
     repos = c(CRAN = getOption("minicran.mran")),
     type = "source"
   )
+
+  if(require(igraph)) plot(p)
+
+  # Same thing without suggests
+
+  p <- makeDepGraph(
+    c("ggplot2", "forecast"),
+    repos = c(CRAN = getOption("minicran.mran")),
+    type = "source",
+    suggests = FALSE
+  )
+
+  if(require(igraph)) plot(p)
+
+
+  # Same thing without suggests and recursive dependencies
+
+  p <- makeDepGraph(
+    c("ggplot2", "forecast"),
+    repos = c(CRAN = getOption("minicran.mran")),
+    type = "source",
+    suggests = FALSE,
+    recursive = FALSE
+  )
+
   if(requireNamespace("igraph", quietly = TRUE)) {
     plot(p)
   } else {
     message("install package `igraph` to view dependency graph")
   }
-  
 }
 }
 \seealso{

--- a/man/miniCRAN-package.Rd
+++ b/man/miniCRAN-package.Rd
@@ -101,6 +101,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item Alex Chubaty \email{alex.chubaty@gmail.com} [contributor]
+  \item Alexandre Courtiol \email{alexandre.courtiol@gmail.com} [contributor]
   \item Microsoft Corporation [copyright holder]
 }
 

--- a/man/pkgDep.Rd
+++ b/man/pkgDep.Rd
@@ -42,7 +42,7 @@ installed on other platforms.  Passed to \code{\link[=download.packages]{downloa
 
 \item{includeBasePkgs}{If TRUE, include base R packages in results}
 
-\item{recursive}{If TRUE, (reverse) dependencies of (reverse) dependencies (and so on) should be included. Input can also be a character vector indicating the type of (reverse) dependencies to be added recursively}
+\item{recursive}{If TRUE, (reverse) dependencies of (reverse) dependencies (and so on) should be included}
 
 \item{Rversion}{Version of R (only used if \code{type} is not \code{source}.) Defaults to \link{R.version}, but this can be specified as any of the following formats:
 \itemize{
@@ -60,7 +60,7 @@ installed on other platforms.  Passed to \code{\link[=download.packages]{downloa
 character vector of package names
 }
 \description{
-Performs recursive retrieve for \code{Depends}, \code{Imports} and \code{LinkLibrary}.
+Performs recursive or non-recursive retrieve for \code{Depends}, \code{Imports} and \code{LinkLibrary}.
 Performs non-recursive retrieve for \code{Suggests}.
 }
 \examples{

--- a/man/pkgDep.Rd
+++ b/man/pkgDep.Rd
@@ -13,6 +13,7 @@ pkgDep(
   suggests = TRUE,
   enhances = FALSE,
   includeBasePkgs = FALSE,
+  recursive = TRUE,
   Rversion = R.version,
   quiet = FALSE,
   ...
@@ -40,6 +41,8 @@ installed on other platforms.  Passed to \code{\link[=download.packages]{downloa
 \item{enhances}{If TRUE, retrieves Enhances dependencies (non-recursively)}
 
 \item{includeBasePkgs}{If TRUE, include base R packages in results}
+
+\item{recursive}{If TRUE, (reverse) dependencies of (reverse) dependencies (and so on) should be included. Input can also be a character vector indicating the type of (reverse) dependencies to be added recursively}
 
 \item{Rversion}{Version of R (only used if \code{type} is not \code{source}.) Defaults to \link{R.version}, but this can be specified as any of the following formats:
 \itemize{

--- a/tests/testthat/test-1-pkgDep.R
+++ b/tests/testthat/test-1-pkgDep.R
@@ -3,63 +3,63 @@ if(interactive()) library(testthat)
 # incorrect package list --------------------------------------------------
 
 test_that("pkgDep throws warnings and errors", {
-  
+
   expect_error(
-    pkgDep(availPkgs = cranJuly2014), 
+    pkgDep(availPkgs = cranJuly2014),
     "argument \"pkg\" is missing, with no default"
   )
-  
+
   expect_error(
-    pkgDep(matrix(1:3, 3), availPkgs = cranJuly2014), 
+    pkgDep(matrix(1:3, 3), availPkgs = cranJuly2014),
     "pkg should be a character vector with package names"
   )
-  
+
   expect_error(
-    pkgDep("reshape99", availPkgs = cranJuly2014), 
+    pkgDep("reshape99", availPkgs = cranJuly2014),
     "No valid packages in pkg"
   )
-  
+
   expect_error(
-    pkgDep(c("reshape98", "reshape99"), availPkgs = cranJuly2014), 
+    pkgDep(c("reshape98", "reshape99"), availPkgs = cranJuly2014),
     "No valid packages in pkg"
   )
-  
+
   expect_warning(
-    pkgDep(c("reshape2", "reshape99"), availPkgs = cranJuly2014), 
+    pkgDep(c("reshape2", "reshape99"), availPkgs = cranJuly2014),
     "Package not recognized: reshape99"
   )
-  
-  
+
+
 })
 
 
 # suggests ----------------------------------------------------------------
 
 test_that("pkgDep treats suggests correctly", {
-  
+
   exp <- pkgDep("ggplot2", availPkgs = cranJuly2014, suggests=FALSE)
   expect_s3_class(exp, "pkgDep")
   expect_identical(
-    as.vector(exp), 
-    c("ggplot2", "plyr", "digest", "gtable", "reshape2", "scales", 
-      "proto", "MASS", "Rcpp", "stringr", "RColorBrewer", "dichromat", 
+    as.vector(exp),
+    c("ggplot2", "plyr", "digest", "gtable", "reshape2", "scales",
+      "proto", "MASS", "Rcpp", "stringr", "RColorBrewer", "dichromat",
       "munsell", "labeling", "colorspace")
   )
-  
+
   exp <- pkgDep("ggplot2", availPkgs = cranJuly2014, suggests=TRUE)
   expect_s3_class(exp, "pkgDep")
   expect_identical(
-    as.vector(exp), 
-    c("ggplot2", "plyr", "digest", "gtable", "reshape2", "scales", 
-      "proto", "MASS", "Rcpp", "stringr", "RColorBrewer", "dichromat", 
-      "munsell", "labeling", "colorspace", "SparseM", "lattice", "survival", 
-      "Formula", "latticeExtra", "cluster", "maps", "sp", "foreign", 
-      "mvtnorm", "TH.data", "sandwich", "zoo", "evaluate", "formatR", 
-      "highr", "markdown", "mime", "nlme", "Matrix", "quantreg", 
-      "Hmisc", "mapproj", "hexbin", "maptools", "multcomp", "testthat", 
+    as.vector(exp),
+    c("ggplot2", "plyr", "digest", "gtable", "reshape2", "scales",
+      "proto", "MASS", "Rcpp", "stringr", "RColorBrewer", "dichromat",
+      "munsell", "labeling", "colorspace", "SparseM", "lattice", "survival",
+      "Formula", "latticeExtra", "cluster", "maps", "sp", "foreign",
+      "mvtnorm", "TH.data", "sandwich", "zoo", "evaluate", "formatR",
+      "highr", "markdown", "mime", "nlme", "Matrix", "quantreg",
+      "Hmisc", "mapproj", "hexbin", "maptools", "multcomp", "testthat",
       "knitr", "mgcv")
   )
-  
+
 })
 
 
@@ -69,18 +69,37 @@ test_that("pkgDep treats includeBasePkgs correctly", {
   exp <- pkgDep("reshape2", includeBasePkgs=TRUE, availPkgs = cranJuly2014, suggests=FALSE)
   expect_s3_class(exp, "pkgDep")
   expect_identical(
-    as.vector(exp), 
+    as.vector(exp),
     c("reshape2", "plyr", "stringr", "Rcpp", "methods")
   )
-  
+
   exp <- pkgDep("reshape2", includeBasePkgs=FALSE, availPkgs = cranJuly2014, suggests=FALSE)
   expect_s3_class(exp, "pkgDep")
   expect_identical(
-    as.vector(exp), 
+    as.vector(exp),
     c("reshape2", "plyr", "stringr", "Rcpp")
   )
-  
+
 })
 
+# recursive ---------------------------------------------------------
 
+test_that("pkgDep treats recursive correctly", {
+  exp <- pkgDep("forecast", recursive=TRUE, availPkgs = cranJuly2014, suggests=FALSE)
+  expect_s3_class(exp, "pkgDep")
+  expect_identical(
+    as.vector(exp),
+    c("forecast", "zoo", "timeDate", "tseries", "fracdiff", "Rcpp",
+      "nnet", "colorspace", "RcppArmadillo", "quadprog", "lattice")
+  )
+
+  exp <- pkgDep("forecast", recursive=FALSE, availPkgs = cranJuly2014, suggests=FALSE)
+  expect_s3_class(exp, "pkgDep")
+  expect_identical(
+    as.vector(exp),
+    c("forecast", "zoo", "timeDate", "tseries", "fracdiff", "Rcpp",
+      "nnet", "colorspace", "RcppArmadillo")
+  )
+
+})
 

--- a/tests/testthat/test-1-pkgDep.R
+++ b/tests/testthat/test-1-pkgDep.R
@@ -85,20 +85,27 @@ test_that("pkgDep treats includeBasePkgs correctly", {
 # recursive ---------------------------------------------------------
 
 test_that("pkgDep treats recursive correctly", {
-  exp <- pkgDep("forecast", recursive=TRUE, availPkgs = cranJuly2014, suggests=FALSE)
+  exp <- pkgDep("chron", recursive = TRUE, availPkgs = cranJuly2014)
   expect_s3_class(exp, "pkgDep")
   expect_identical(
     as.vector(exp),
-    c("forecast", "zoo", "timeDate", "tseries", "fracdiff", "Rcpp",
-      "nnet", "colorspace", "RcppArmadillo", "quadprog", "lattice")
+    c("chron", "RColorBrewer", "dichromat", "munsell", "plyr", "labeling",
+      "colorspace", "Rcpp", "digest", "gtable", "reshape2", "scales",
+      "proto", "MASS", "stringr", "ggplot2")
   )
 
-  exp <- pkgDep("forecast", recursive=FALSE, availPkgs = cranJuly2014, suggests=FALSE)
+  exp <- pkgDep("chron", recursive = FALSE, availPkgs = cranJuly2014, suggests = FALSE)
   expect_s3_class(exp, "pkgDep")
   expect_identical(
     as.vector(exp),
-    c("forecast", "zoo", "timeDate", "tseries", "fracdiff", "Rcpp",
-      "nnet", "colorspace", "RcppArmadillo")
+    c("chron")
+  )
+
+  exp <- pkgDep("chron", recursive = FALSE, availPkgs = cranJuly2014, suggests = TRUE)
+  expect_s3_class(exp, "pkgDep")
+  expect_identical(
+    as.vector(exp),
+    c("chron", "scales", "ggplot2")
   )
 
 })

--- a/tests/testthat/test-2-makeDepGraph.R
+++ b/tests/testthat/test-2-makeDepGraph.R
@@ -85,6 +85,12 @@ test_that("makeDepGraph and pgkDep gives similar results for MASS", {
   expect_true(
     checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
   )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = TRUE, recursive = FALSE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, enhances = TRUE, recursive = FALSE)
+  )
 
 })
 
@@ -109,6 +115,12 @@ test_that("makeDepGraph and pgkDep gives similar results for chron", {
   )
   expect_true(
     checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = TRUE, recursive = FALSE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, enhances = TRUE, recursive = FALSE)
   )
 
 })
@@ -135,6 +147,12 @@ test_that("makeDepGraph and pgkDep gives similar results for data.table", {
   expect_true(
     checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
   )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = TRUE, recursive = FALSE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, enhances = TRUE, recursive = FALSE)
+  )
 
 })
 
@@ -158,6 +176,12 @@ test_that("makeDepGraph and pgkDep gives similar results for ggplot2", {
   )
   expect_true(
     checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = TRUE, recursive = FALSE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, enhances = TRUE, recursive = FALSE)
   )
 
 })
@@ -183,6 +207,12 @@ test_that("makeDepGraph and pgkDep gives similar results for complex query", {
   )
   expect_true(
     checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = TRUE, recursive = FALSE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, enhances = TRUE, recursive = FALSE)
   )
 
 })

--- a/tests/testthat/test-2-makeDepGraph.R
+++ b/tests/testthat/test-2-makeDepGraph.R
@@ -3,16 +3,19 @@ checkPkgDepFunctions <- function(pkg, availPkgs = cranJuly2014,
                                  type = "source",
                                  suggests = TRUE,
                                  enhances = FALSE,
-                                 includeBasePkgs = FALSE) {
+                                 includeBasePkgs = FALSE,
+                                 recursive = TRUE) {
 
   p1 <- pkgDep(pkg, availPkgs = availPkgs,
                repos = repos, type = type,
                suggests = suggests, enhances = enhances,
-               includeBasePkgs = includeBasePkgs)
+               includeBasePkgs = includeBasePkgs,
+               recursive = recursive)
   p2 <- makeDepGraph(pkg, availPkgs = availPkgs,
                      repos = repos, type = type,
                      suggests = suggests, enhances = enhances,
-                     includeBasePkgs = includeBasePkgs)
+                     includeBasePkgs = includeBasePkgs,
+                     recursive = recursive)
 
   vnames <- igraph::V(p2)$name
   diff1 <- setdiff(vnames, p1)
@@ -79,6 +82,9 @@ test_that("makeDepGraph and pgkDep gives similar results for MASS", {
   expect_true(
     checkPkgDepFunctions(tag, includeBasePkgs = TRUE, enhances = TRUE)
   )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
+  )
 
 })
 
@@ -100,6 +106,9 @@ test_that("makeDepGraph and pgkDep gives similar results for chron", {
   )
   expect_true(
     checkPkgDepFunctions(tag, includeBasePkgs = TRUE, enhances = TRUE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
   )
 
 })
@@ -123,6 +132,9 @@ test_that("makeDepGraph and pgkDep gives similar results for data.table", {
   expect_true(
     checkPkgDepFunctions(tag, includeBasePkgs = TRUE, enhances = TRUE)
   )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
+  )
 
 })
 
@@ -143,6 +155,9 @@ test_that("makeDepGraph and pgkDep gives similar results for ggplot2", {
   )
   expect_true(
     checkPkgDepFunctions(tag, includeBasePkgs = TRUE, enhances = TRUE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
   )
 
 })
@@ -165,6 +180,9 @@ test_that("makeDepGraph and pgkDep gives similar results for complex query", {
   )
   expect_true(
     checkPkgDepFunctions(tag, includeBasePkgs = TRUE, enhances = TRUE)
+  )
+  expect_true(
+    checkPkgDepFunctions(tag, suggests = FALSE, recursive = FALSE)
   )
 
 })


### PR DESCRIPTION
Fixes #149 

The idea of this PR is the reduce a little further the clutter while remaining accurate.
Here is an example with **dplyr**, a package with a lot of dependencies.
The basic plot is quite unreadable because it shows too much:

``` r
library(miniCRAN)
plot(makeDepGraph(pkg = "dplyr"))
```
![](https://i.imgur.com/4yNukRj.png)

The situation improves if suggested packages are turned off:
``` r
plot(makeDepGraph(pkg = "dplyr", suggests = FALSE))
```
![](https://i.imgur.com/1EzHYhc.png)

But one could argue, do we really need here to show e.g. **pkgconfig** which is only on indirect dependencies (imported by **tibble**, which is itself imported by **dplyr**).

What I did was thus to refine the internal call to `tools::package_dependencies()` so as to exploit the argument it contains called `recursive`. It was hard-coded as `TRUE` but now the user can control it:

``` r
plot(makeDepGraph(pkg = "dplyr", suggests = FALSE, recursive = FALSE))
```
![](https://i.imgur.com/1vrcVVl.png)

Note that contrary to the original argument `recursive` in  `tools::package_dependencies()` which allows for both logical or character vector input, I restricted the use to a logical only. I explored the alternative but it would lead to quite a lot of changes in the code.

I paid attention to update the package examples, tests, news and description.

R CMD check does not complain about anything on my system.
